### PR TITLE
fix: useDarkMode produces infinite re-renders when using a decorator

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,7 +6,7 @@ import { store } from './Tool';
  * Returns the current state of storybook's dark-mode
  */
 export function useDarkMode(): boolean {
-  const [isDark, setIsDark] = useState(store().current === 'dark');
+  const [isDark, setIsDark] = useState(() => store().current === 'dark');
 
   useEffect(() => {
     const chan = addons.getChannel();


### PR DESCRIPTION
Good time of the day, team!
Thank you for creating the library!

Using this add-on we have spotted that the hook `useDarkMode` generates infinite re-renders when we use it inside a Story decorator, which created issues for our tests, and overall is not great for performance.

The solution is based on the React state pattern of lazy state initialization.