### PR TITLE
docs: update `DocsContainer` import

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,7 @@ export const decorators = [
 Docs have a dedicated container component which will _not_ be themed unless you explicitly configure it:
 
 ```js
+import { DocsContainer } from '@storybook/addon-docs/blocks';
 import { useIsDarkMode } from './hooks'; // the hook we defined above
 
 function ThemedDocsContainer(props) {
@@ -290,7 +291,7 @@ By editing your `.storybook/preview.js`.
 ```js
 import React from 'react';
 import { addons } from 'storybook/preview-api';
-import { DocsContainer } from '@storybook/addon-docs';
+import { DocsContainer } from '@storybook/addon-docs/blocks';
 import { themes } from 'storybook/theming';
 
 import {


### PR DESCRIPTION
As seen [here](https://storybook.js.org/docs/writing-docs/autodocs#customize-the-docs-container), it seems `DocsContainer` needs to be imported from '@storybook/addon-docs/blocks'

I'm in the process of migrating from Storybook v8 to v9, I used `storybook-dark-mode` which was working well, so I'm now switching to this new addon. Thanks for this!