### PR TITLE
PnP support Storybook 10

### DIFF
--- a/preset.js
+++ b/preset.js
@@ -1,7 +1,7 @@
 import { fileURLToPath } from "url";
 
 function managerEntries(entry = []) {
-  return [...entry, fileURLToPath(import.meta.resolve("./dist/manager"))];
+  return [...entry, fileURLToPath(import.meta.resolve("./dist/manager.js"))];
 }
 
 export { managerEntries };


### PR DESCRIPTION
Resolved manager bundle with explicit `.js` for yarn PnP.
Node ESM requires file extensions in import.meta.resolve; extensionless `./dist/manager` breaks under Yarn PnP while pnpm was more permissive.